### PR TITLE
Commented out bootstrap icon

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -13,7 +13,7 @@ class PostsController extends Controller
      */
     public function index()
     {
-        //
+        // 
     }
 
     /**

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -7,7 +7,7 @@
     <title>Laravel Blog</title>
       <!-- CSS -->
       <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500&display=swap">
-      <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+      <!-- <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous"> -->
       <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
       <link rel="stylesheet" href="{{ asset('assets/css/jquery.mCustomScrollbar.min.css')}}">
       <link rel="stylesheet" href="{{ asset('assets/css/animate.css')}}">
@@ -15,7 +15,7 @@
       <link rel="stylesheet" href="{{ asset('assets/css/media-queries.css')}}">
         <link rel="stylesheet" href="{{ asset('assets/css/style_1.css')}}">
       <!-- Favicon and touch icons -->
-      <link rel="shortcut icon" href="images/1.jpg">
+      <link rel="shortcut icon" href="/images/1.jpg">
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.3.0/font/bootstrap-icons.css">
       <link rel="apple-touch-icon-precomposed" sizes="144x144" href="assets/ico/apple-touch-icon-144-precomposed.png">
       <link rel="apple-touch-icon-precomposed" sizes="114x114" href="assets/ico/apple-touch-icon-114-precomposed.png">


### PR DESCRIPTION
I commented out the bootstrap icon cdn link so we can use only fontawesome.

Using both of them will increase load time especially when font awesome is sufficient.